### PR TITLE
feat(model): implement dynamic model selection with custom model support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,12 @@
           ],
           "order": 2
         },
+        "claudex.customModel": {
+          "type": "string",
+          "markdownDescription": "自定义模型列表，逗号分隔；示例：`my-model-a, my-model-b`",
+          "default": "",
+          "order": 2.1
+        },
         "claudex.permissionMode": {
           "type": "string",
           "markdownDescription": "权限模式",

--- a/webview/src/components/ButtonArea.vue
+++ b/webview/src/components/ButtonArea.vue
@@ -85,28 +85,19 @@
           </template>
 
           <template #content="{ close }">
-            <DropdownItem
-              :item="{
-                id: 'claude-4-sonnet',
-                label: 'claude-4-sonnet',
-                checked: selectedModelLocal === 'claude-4-sonnet',
-                type: 'model'
-              }"
-              :is-selected="selectedModelLocal === 'claude-4-sonnet'"
-              :index="0"
-              @click="(item) => handleModelSelect(item, close)"
-            />
-            <DropdownItem
-              :item="{
-                id: 'claude-4.1-opus',
-                label: 'claude-4.1-opus',
-                checked: selectedModelLocal === 'claude-4.1-opus',
-                type: 'model'
-              }"
-              :is-selected="selectedModelLocal === 'claude-4.1-opus'"
-              :index="1"
-              @click="(item) => handleModelSelect(item, close)"
-            />
+            <template v-for="(m, idx) in modelOptions" :key="m">
+              <DropdownItem
+                :item="{
+                  id: m,
+                  label: m,
+                  checked: selectedModelLocal === m,
+                  type: 'model'
+                }"
+                :is-selected="selectedModelLocal === m"
+                :index="idx"
+                @click="(item) => handleModelSelect(item, close)"
+              />
+            </template>
             <DropdownSeparator />
             <DropdownItem
               :item="{
@@ -115,8 +106,8 @@
                 rightIcon: 'codicon-chevron-right',
                 type: 'action'
               }"
-              :index="2"
-              @click="(item) => handleModelSelect(item, close)"
+              :index="modelOptions.length + 1"
+              @click="() => handleOpenModelSettings(close)"
             />
           </template>
         </DropdownTrigger>
@@ -166,6 +157,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { DropdownTrigger, DropdownItem, DropdownSeparator, type DropdownItemData } from './Dropdown'
+import { modelState, openSettings } from '../services/messageBus'
 
 interface Props {
   disabled?: boolean
@@ -192,7 +184,8 @@ const props = withDefaults(defineProps<Props>(), {
   hasInputContent: false
 })
 
-const selectedModelLocal = ref(props.selectedModel)
+const selectedModelLocal = computed(() => modelState.selected || props.selectedModel)
+const modelOptions = computed(() => modelState.options.length ? modelState.options : [props.selectedModel])
 
 const emit = defineEmits<Emits>()
 
@@ -260,18 +253,19 @@ function handleModelDropdown() {
 
 function handleModelSelect(item: DropdownItemData, close: () => void) {
   console.log('Selected model:', item)
-  selectedModelLocal.value = item.id
+  // 更新全局选中模型
+  if (item.type === 'model') {
+    modelState.selected = String(item.id)
+  }
   close()
 
   // 可以在这里添加模型切换的业务逻辑
-  switch (item.id) {
-    case 'claude-4-sonnet':
-      console.log('Switching to Claude 4 Sonnet')
-      break
-    case 'claude-4.1-opus':
-      console.log('Switching to Claude 4.1 Opus')
-      break
-  }
+  console.log('Switched model to:', item.id)
+}
+
+function handleOpenModelSettings(close: () => void) {
+  openSettings('claudex.customModel')
+  close()
 }
 </script>
 

--- a/webview/src/pages/ChatPage.vue
+++ b/webview/src/pages/ChatPage.vue
@@ -79,6 +79,7 @@ import ChatInputBox from '../components/ChatInputBox.vue';
 import InputExtraBox from '../components/InputExtraBox.vue';
 import MessageContainer from '../components/Messages/MessageContainer.vue';
 import type { Todo, FileEdit } from '../../types/toolbar';
+import { modelState } from '../services/messageBus';
 
 // 定义事件
 const emit = defineEmits<{
@@ -86,7 +87,7 @@ const emit = defineEmits<{
 }>();
 
 const progressPercentage = ref(48.7);
-const selectedModel = ref('claude-4-sonnet');
+const selectedModel = computed(() => modelState.selected);
 
 // 计算聊天标题
 const chatTitle = computed(() => {

--- a/webview/types/messages.ts
+++ b/webview/types/messages.ts
@@ -91,6 +91,8 @@ export interface SystemReadyMessage extends BaseMessage {
   type: 'system/ready';
   payload: {
     capabilities: string[];
+    models?: string[];
+    selectedModel?: string;
   };
 }
 
@@ -144,6 +146,7 @@ export interface ChatSendMessage extends BaseMessage {
   payload: {
     text: string;
     sessionId?: string;
+    model?: string;
   };
 }
 
@@ -167,6 +170,14 @@ export interface PermissionResponseMessage extends BaseMessage {
   };
 }
 
+// 打开设置
+export interface SettingsOpenMessage extends BaseMessage {
+  type: 'settings/open';
+  payload: {
+    query?: string;
+  };
+}
+
 // ========== 联合类型 ==========
 
 // Extension发出的所有消息
@@ -187,7 +198,8 @@ export type WebviewMessage =
   | SessionSwitchMessage
   | ChatSendMessage
   | ChatInterruptMessage
-  | PermissionResponseMessage;
+  | PermissionResponseMessage
+  | SettingsOpenMessage;
 
 // 所有消息的联合类型
 export type Message = ExtensionMessage | WebviewMessage;


### PR DESCRIPTION
- Add 'claudex.customModel' configuration for user-defined model list
- Implement config watcher in ClaudeClient to push model updates to webview
- Support model parameter in chat/send request payload
- Add reactive modelState in messageBus for global model selection
- Render model dropdown dynamically from system/ready payload
- Add "Manage Models" entry to open settings page directly

This feature allows users to configure custom models via settings and switch between them seamlessly in the chat interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement dynamic model selection with custom model support by introducing a new configuration setting, watching for setting changes, extending the messaging protocol, and updating the UI to render and switch between models dynamically.

New Features:
- Add 'claudex.customModel' setting to allow users to define custom models via a comma-separated list
- Watch for 'claudex.customModel' and 'claudex.model' changes in ClaudeClient and push updated model lists and selected model to the webview
- Support specifying a model parameter in chat/send requests and route it through the Claude agent
- Render a dynamic model dropdown in the chat UI driven by a reactive modelState
- Add a "Manage Models" entry in the UI to open the settings page directly for configuring models

Enhancements:
- Refactor ButtonArea.vue and ChatPage.vue to use reactive modelState instead of hardcoded model items
- Extend the messaging protocol to include models and selectedModel in system/ready messages and introduce a settings/open message
- Properly dispose of the configuration watcher when the client shuts down
- Update package.json to include schema definitions for the new 'claudex.customModel' configuration